### PR TITLE
Fix project_info to contain updated board_part

### DIFF
--- a/project_info.tcl
+++ b/project_info.tcl
@@ -2,7 +2,7 @@
 proc set_project_properties_post_create_project {proj_name} {
     set project_obj [get_projects $proj_name]
     set_property "part" "xc7z020clg484-1" $project_obj
-    set_property "board_part" "em.avnet.com:zed:part0:1.4" $project_obj
+    set_property "board_part" "avnet.com:zedboard:part0:1.4" $project_obj
     set_property "default_lib" "xil_defaultlib" $project_obj
     set_property "simulator_language" "Mixed" $project_obj
     set_property "target_language" "VHDL" $project_obj


### PR DESCRIPTION
The 2022.1 upgrade required changing the project board_part from `em.avnet.com:zed:part0:1.4` to `avnet.com:zedboard:part0:1.4`. At the time of building and exporting the hardware platform, this change was applied to the project's state, but the checkin script failed to also save it because of the DOCUMENTED behaviour that project_info.tcl is not recreated if it already exists. This commit adds this change to project_info.tcl but WILL NOT be followed by another hardware export commit.